### PR TITLE
add hashtag-temp feature

### DIFF
--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -2,7 +2,7 @@ import api from '../api';
 import { CancelToken, isCancel } from 'axios';
 import { throttle } from 'lodash';
 import { search as emojiSearch } from '../features/emoji/emoji_mart_search_light';
-import { tagHistory } from '../settings';
+import { tagHistory, tagTemplate } from '../settings';
 import { useEmoji } from './emojis';
 import resizeImage from '../utils/resize_image';
 import { importFetchedAccounts } from './importer';
@@ -32,6 +32,8 @@ export const COMPOSE_SUGGESTION_SELECT = 'COMPOSE_SUGGESTION_SELECT';
 export const COMPOSE_SUGGESTION_TAGS_UPDATE = 'COMPOSE_SUGGESTION_TAGS_UPDATE';
 
 export const COMPOSE_TAG_HISTORY_UPDATE = 'COMPOSE_TAG_HISTORY_UPDATE';
+
+export const COMPOSE_TAG_TEMPLATE_UPDATE = 'COMPOSE_TAG_TEMPLATE_UPDATE';
 
 export const COMPOSE_MOUNT   = 'COMPOSE_MOUNT';
 export const COMPOSE_UNMOUNT = 'COMPOSE_UNMOUNT';
@@ -109,11 +111,17 @@ export function directCompose(account, routerHistory) {
 
 export function submitCompose(routerHistory) {
   return function (dispatch, getState) {
-    const status = getState().getIn(['compose', 'text'], '');
+    let status = getState().getIn(['compose', 'text'], '');
     const media  = getState().getIn(['compose', 'media_attachments']);
 
     if ((!status || !status.length) && media.size === 0) {
       return;
+    }
+
+    const hashtag = getState().getIn(['compose', 'tagTemplate'], '');
+
+    if (hashtag && hashtag.length) {
+      status = [status, ` #${hashtag}`].join('');
     }
 
     dispatch(submitComposeRequest());
@@ -384,6 +392,30 @@ export function updateTagHistory(tags) {
     type: COMPOSE_TAG_HISTORY_UPDATE,
     tags,
   };
+}
+
+export function updateTagTemplate(tag) {
+  return (dispatch, getState) => {
+    dispatch({
+      type: COMPOSE_TAG_TEMPLATE_UPDATE,
+      tag,
+    });
+
+    const me = getState().getIn(['meta', 'me']);
+    tagTemplate.set(me, tag);
+  };
+}
+
+export function addTagTemplateInput() {
+}
+
+export function delTagTemplateInput() {
+}
+
+export function enableTagTemplage(key) {
+}
+
+export function disableTagTemplage(key) {
 }
 
 export function hydrateCompose() {

--- a/app/javascript/mastodon/components/hashtag_temp.js
+++ b/app/javascript/mastodon/components/hashtag_temp.js
@@ -1,0 +1,178 @@
+import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import PropTypes from 'prop-types';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+
+const getHashtagWord = (value) => {
+  if (!value) {
+    return '';
+  }
+
+  const trimmed = value.trim();
+  return (trimmed[0] === '#') ? trimmed.slice(1) : trimmed;
+};
+
+export default class HashtagTemp extends ImmutablePureComponent {
+
+  static propTypes = {
+    disabled: PropTypes.bool,
+    value: PropTypes.string,
+    placeholder: PropTypes.string,
+    onSuggestionsClearRequested: PropTypes.func.isRequired,
+    onSuggestionsFetchRequested: PropTypes.func.isRequired,
+    onKeyUp: PropTypes.func,
+    onKeyDown: PropTypes.func,
+    suggestions: ImmutablePropTypes.list,
+    onChangeTagTemplate: PropTypes.func,
+  };
+
+  state = {
+    suggestionsHidden: false,
+    selectedSuggestion: 0,
+    lastToken: null,
+  };
+
+  onChange = (e) => {
+    const { value } = e.target;
+    const hashtag = getHashtagWord(value);
+    this.props.onChangeTagTemplate(hashtag);
+    if (hashtag) {
+      this.setState({ value, lastToken: hashtag });
+      this.props.onSuggestionsFetchRequested(hashtag);
+    } else {
+      this.setState({ value, lastToken: null });
+      this.props.onSuggestionsClearRequested();
+    }
+  }
+
+  onKeyDown = (e) => {
+    const { disabled, suggestions } = this.props;
+    const { value, suggestionsHidden, selectedSuggestion } = this.state;
+
+    if (disabled) {
+      e.preventDefault();
+      return;
+    }
+
+    switch(e.key) {
+    case 'Escape':
+      if (!suggestionsHidden) {
+        e.preventDefault();
+        this.setState({ suggestionsHidden: true });
+      }
+
+      break;
+    case 'ArrowDown':
+      if (suggestions.size > 0 && !suggestionsHidden) {
+        e.preventDefault();
+        this.setState({ selectedSuggestion: Math.min(selectedSuggestion + 1, suggestions.size - 1) });
+      }
+
+      break;
+    case 'ArrowUp':
+      if (suggestions.size > 0 && !suggestionsHidden) {
+        e.preventDefault();
+        this.setState({ selectedSuggestion: Math.max(selectedSuggestion -1, 0) });
+      }
+
+      break;
+    case 'Enter':
+    case 'Tab':
+      // Note: Ignore the event of Confirm Conversion of IME
+      if (e.keyCode === 229) {
+        break;
+      }
+
+      if (this.state.lastToken !== null && suggestions.size > 0 && !suggestionsHidden) {
+        e.preventDefault();
+        this.insertHashtag(suggestions.get(selectedSuggestion));
+      } else if (e.keyCode === 13) {
+        e.preventDefault();
+        this.insertHashtag(value);
+      }
+
+      break;
+    }
+
+    if (e.defaultPrevented || !this.props.onKeyDown) {
+      return;
+    }
+
+    this.props.onKeyDown(e);
+  }
+
+  onBlur = () => {
+    this.setState({ suggestionsHidden: true });
+  }
+
+  insertHashtag = (value) => {
+    const hashtag = getHashtagWord(value);
+    this.props.onChangeTagTemplate(hashtag);
+    if (hashtag) {
+      this.props.onSuggestionsClearRequested();
+      this.setState({
+	      value: hashtag,
+        suggestionsHidden: true,
+        selectedSuggestion: 0,
+        lastToken: null,
+      });
+    }
+  }
+
+  onSuggestionClick = (e) => {
+    e.preventDefault();
+    const { suggestions } = this.props;
+    const index = e.currentTarget.getAttribute('data-index');
+    this.insertHashtag(suggestions.get(index));
+  }
+
+  componentWillReceiveProps (nextProps) {
+    if (nextProps.suggestions !== this.props.suggestions &&
+      nextProps.suggestions.size > 0 && this.state.suggestionsHidden) {
+      this.setState({ suggestionsHidden: false });
+    }
+  }
+
+  renderHashTagSuggestion = (tag, i) => {
+    const { selectedSuggestion } = this.state;
+
+    return (
+      <div
+        role='button'
+        tabIndex='0'
+        key={tag}
+        className={`autosuggest-textarea__suggestions__item ${i === selectedSuggestion ? 'selected' : ''}`}
+        data-index={i}
+        onMouseDown={this.onSuggestionClick}
+      >
+        {tag}
+      </div>
+    );
+  }
+
+  render () {
+    const { value, suggestions, disabled, placeholder, onKeyUp } = this.props;
+    const { suggestionsHidden } = this.state;
+
+    return (
+      <div className='hashtag-temp'>
+        <i className='fa fa-fw fa-hashtag' />
+        <input
+          className='hastag-temp__input'
+          disabled={disabled}
+          placeholder={placeholder}
+          value={value}
+          onChange={this.onChange}
+          onKeyDown={this.onKeyDown}
+          onKeyUp={onKeyUp}
+          onBlur={this.onBlur}
+        />
+
+        <div style={{ display: (suggestions.size > 0 && !suggestionsHidden) ? 'block' : 'none' }}  className='autosuggest-textarea__suggestions'>
+          {suggestions.map(this.renderHashTagSuggestion)}
+        </div>
+      </div>
+    );
+  }
+
+}

--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -3,8 +3,10 @@ import CharacterCounter from './character_counter';
 import Button from '../../../components/button';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
+import Immutable from 'immutable';
 import ReplyIndicatorContainer from '../containers/reply_indicator_container';
 import AutosuggestTextarea from '../../../components/autosuggest_textarea';
+import HashtagTemp from '../../../components/hashtag_temp';
 import UploadButtonContainer from '../containers/upload_button_container';
 import { defineMessages, injectIntl } from 'react-intl';
 import SpoilerButtonContainer from '../containers/spoiler_button_container';
@@ -23,6 +25,7 @@ const allowedAroundShortCode = '><\u0085\u0020\u00a0\u1680\u2000\u2001\u2002\u20
 const messages = defineMessages({
   placeholder: { id: 'compose_form.placeholder', defaultMessage: 'What is on your mind?' },
   spoiler_placeholder: { id: 'compose_form.spoiler_placeholder', defaultMessage: 'Write your warning here' },
+  hashtag_temp_placeholder: { id: 'compose_form.hashtag_temp_placeholder', defaultMessage: 'Append tag' },
   publish: { id: 'compose_form.publish', defaultMessage: 'Toot' },
   publishLoud: { id: 'compose_form.publish_loud', defaultMessage: '{publish}!' },
 });
@@ -58,6 +61,8 @@ class ComposeForm extends ImmutablePureComponent {
     onPickEmoji: PropTypes.func.isRequired,
     showSearch: PropTypes.bool,
     anyMedia: PropTypes.bool,
+    tagTemplate: PropTypes.string,
+    onChangeTagTemplate: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
@@ -67,6 +72,8 @@ class ComposeForm extends ImmutablePureComponent {
   handleChange = (e) => {
     this.props.onChange(e.target.value);
   }
+
+  state = { tagSuggestionFrom: null }
 
   handleKeyDown = (e) => {
     if (e.keyCode === 13 && (e.ctrlKey || e.metaKey)) {
@@ -94,14 +101,22 @@ class ComposeForm extends ImmutablePureComponent {
 
   onSuggestionsClearRequested = () => {
     this.props.onClearSuggestions();
+    this.setState({ tagSuggestionFrom: null });
   }
 
   onSuggestionsFetchRequested = (token) => {
+    this.setState({ tagSuggestionFrom: 'autosuggested-textarea' });
     this.props.onFetchSuggestions(token);
   }
 
   onSuggestionSelected = (tokenStart, token, value) => {
     this.props.onSuggestionSelected(tokenStart, token, value);
+    this.setState({ tagSuggestionFrom: null });
+  }
+
+  onHashTagSuggestionsFetchRequested = (token) => {
+    this.setState({ tagSuggestionFrom: 'hashtag-temp' });
+    this.props.onFetchSuggestions(`#${token}`);
   }
 
   handleChangeSpoilerText = (e) => {
@@ -158,9 +173,11 @@ class ComposeForm extends ImmutablePureComponent {
   }
 
   render () {
-    const { intl, onPaste, showSearch, anyMedia } = this.props;
+    const { intl, onPaste, showSearch, anyMedia, tagTemplate } = this.props;
+    const { tagSuggestionFrom } = this.state;
     const disabled = this.props.is_submitting;
-    const text     = [this.props.spoiler_text, countableText(this.props.text)].join('');
+    const preTagTemplate = tagTemplate.length > 0 ? ' #' : '';
+    const text     = [this.props.spoiler_text, countableText(this.props.text), preTagTemplate+tagTemplate].join('');
     const disabledButton = disabled || this.props.is_uploading || this.props.is_changing_upload || length(text) > 500 || (text.length !== 0 && text.trim().length === 0 && !anyMedia);
     let publishText = '';
 
@@ -190,7 +207,7 @@ class ComposeForm extends ImmutablePureComponent {
             disabled={disabled}
             value={this.props.text}
             onChange={this.handleChange}
-            suggestions={this.props.suggestions}
+            suggestions={tagSuggestionFrom === 'autosuggested-textarea' ? this.props.suggestions : Immutable.List()}
             onKeyDown={this.handleKeyDown}
             onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
             onSuggestionsClearRequested={this.onSuggestionsClearRequested}
@@ -204,7 +221,16 @@ class ComposeForm extends ImmutablePureComponent {
 
         <div className='compose-form__modifiers'>
           <UploadFormContainer />
-        </div>
+          <HashtagTemp
+            placeholder={intl.formatMessage(messages.hashtag_temp_placeholder)}
+            disabled={disabled}
+            value={tagTemplate}
+            suggestions={tagSuggestionFrom === 'hashtag-temp' ? this.props.suggestions : Immutable.List()}
+            onSuggestionsFetchRequested={this.onHashTagSuggestionsFetchRequested}
+            onSuggestionsClearRequested={this.onSuggestionsClearRequested}
+            onChangeTagTemplate={this.props.onChangeTagTemplate}
+          />
+	      </div>
 
         <div className='compose-form__buttons-wrapper'>
           <div className='compose-form__buttons'>

--- a/app/javascript/mastodon/features/compose/containers/compose_form_container.js
+++ b/app/javascript/mastodon/features/compose/containers/compose_form_container.js
@@ -9,6 +9,7 @@ import {
   selectComposeSuggestion,
   changeComposeSpoilerText,
   insertEmojiCompose,
+  updateTagTemplate,
 } from '../../../actions/compose';
 
 const mapStateToProps = state => ({
@@ -26,6 +27,7 @@ const mapStateToProps = state => ({
   is_uploading: state.getIn(['compose', 'is_uploading']),
   showSearch: state.getIn(['search', 'submitted']) && !state.getIn(['search', 'hidden']),
   anyMedia: state.getIn(['compose', 'media_attachments']).size > 0,
+  tagTemplate : state.getIn(['compose', 'tagTemplate']),
 });
 
 const mapDispatchToProps = (dispatch) => ({
@@ -62,6 +64,9 @@ const mapDispatchToProps = (dispatch) => ({
     dispatch(insertEmojiCompose(position, data, needsSpace));
   },
 
+  onChangeTagTemplate (tag) {
+    dispatch(updateTagTemplate(tag));
+  }
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(ComposeForm);

--- a/app/javascript/mastodon/features/compose/containers/warning_container.js
+++ b/app/javascript/mastodon/features/compose/containers/warning_container.js
@@ -9,7 +9,7 @@ const APPROX_HASHTAG_RE = /(?:^|[^\/\)\w])#(\w*[a-zA-Z·]\w*)/i;
 
 const mapStateToProps = state => ({
   needsLockWarning: state.getIn(['compose', 'privacy']) === 'private' && !state.getIn(['accounts', me, 'locked']),
-  hashtagWarning: state.getIn(['compose', 'privacy']) !== 'public' && APPROX_HASHTAG_RE.test(state.getIn(['compose', 'text'])),
+  hashtagWarning: state.getIn(['compose', 'privacy']) !== 'public' && (APPROX_HASHTAG_RE.test(state.getIn(['compose', 'text'])) || state.getIn(['compose', 'tagTemplate']).length > 0),
   directMessageWarning: state.getIn(['compose', 'privacy']) === 'direct',
 });
 

--- a/app/javascript/mastodon/locales/ja.json
+++ b/app/javascript/mastodon/locales/ja.json
@@ -69,6 +69,7 @@
   "community.column_settings.media_only": "メディアのみ表示",
   "compose_form.direct_message_warning": "このトゥートはメンションされた人にのみ送信されます。",
   "compose_form.direct_message_warning_learn_more": "もっと詳しく",
+  "compose_form.hashtag_temp_placeholder": "タグを入力",
   "compose_form.hashtag_warning": "このトゥートは未収載なのでハッシュタグの一覧に表示されません。公開トゥートだけがハッシュタグで検索できます。",
   "compose_form.lock_disclaimer": "あなたのアカウントは{locked}になっていません。誰でもあなたをフォローすることができ、フォロワー限定の投稿を見ることができます。",
   "compose_form.lock_disclaimer.lock": "承認制",

--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -19,6 +19,7 @@ import {
   COMPOSE_SUGGESTION_SELECT,
   COMPOSE_SUGGESTION_TAGS_UPDATE,
   COMPOSE_TAG_HISTORY_UPDATE,
+  COMPOSE_TAG_TEMPLATE_UPDATE,
   COMPOSE_SENSITIVITY_CHANGE,
   COMPOSE_SPOILERNESS_CHANGE,
   COMPOSE_SPOILER_TEXT_CHANGE,
@@ -37,6 +38,7 @@ import { Map as ImmutableMap, List as ImmutableList, OrderedSet as ImmutableOrde
 import uuid from '../uuid';
 import { me } from '../initial_state';
 import { unescapeHTML } from '../utils/html';
+import { tagTemplate } from '../settings';
 
 const initialState = ImmutableMap({
   mounted: 0,
@@ -62,6 +64,7 @@ const initialState = ImmutableMap({
   resetFileKey: Math.floor((Math.random() * 0x10000)),
   idempotencyKey: null,
   tagHistory: ImmutableList(),
+  tagTemplate: '',
 });
 
 function statusToTextMentions(state, status) {
@@ -86,6 +89,7 @@ function clearAll(state) {
     map.set('sensitive', false);
     map.update('media_attachments', list => list.clear());
     map.set('idempotencyKey', uuid());
+    map.set('tagTemplate', tagTemplate.get(me));
   });
 };
 
@@ -248,6 +252,7 @@ export default function compose(state = initialState, action) {
       map.set('spoiler_text', '');
       map.set('privacy', state.get('default_privacy'));
       map.set('idempotencyKey', uuid());
+      map.set('tagTemplate', tagTemplate.get(me));
     });
   case COMPOSE_SUBMIT_REQUEST:
     return state.set('is_submitting', true);
@@ -294,6 +299,8 @@ export default function compose(state = initialState, action) {
     return updateSuggestionTags(state, action.token);
   case COMPOSE_TAG_HISTORY_UPDATE:
     return state.set('tagHistory', fromJS(action.tags));
+  case COMPOSE_TAG_TEMPLATE_UPDATE:
+    return state.set('tagTemplate', action.tag);
   case TIMELINE_DELETE:
     if (action.id === state.get('in_reply_to')) {
       return state.set('in_reply_to', null);
@@ -321,6 +328,7 @@ export default function compose(state = initialState, action) {
       map.set('focusDate', new Date());
       map.set('caretPosition', null);
       map.set('idempotencyKey', uuid());
+      map.set('tagTemplate', tagTemplate.get(me));
 
       if (action.status.get('spoiler_text').length > 0) {
         map.set('spoiler', true);

--- a/app/javascript/mastodon/settings.js
+++ b/app/javascript/mastodon/settings.js
@@ -45,3 +45,4 @@ export default class Settings {
 
 export const pushNotificationsSetting = new Settings('mastodon_push_notification_data');
 export const tagHistory = new Settings('mastodon_tag_history');
+export const tagTemplate = new Settings('mastodon_tag_template');

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -304,6 +304,7 @@
   }
 
   .autosuggest-textarea,
+  .hashtag-temp,
   .spoiler-input {
     position: relative;
   }
@@ -320,6 +321,7 @@
   }
 
   .autosuggest-textarea__textarea,
+  .hastag-temp__input,
   .spoiler-input__input {
     display: block;
     box-sizing: border-box;
@@ -5465,5 +5467,23 @@ noscript {
         stroke: lighten($highlight-text-color, 6%) !important;
       }
     }
+  }
+}
+
+.hashtag-temp {
+  display: flex;
+  align-items: center;
+  border-top: 1px solid rgba($ui-base-color, 0.1);
+  font-size: 12px;
+
+  .hastag-temp__input {
+    padding-left: 0;
+    font-size: 12px;
+    border-radius: 0 0 4px;
+  }
+
+  .fa-hashtag {
+    color: rgba($ui-base-color, 0.7);
+    padding-left: 5px;
   }
 }


### PR DESCRIPTION
# 導入方法

## 前提

v2.7.4をベースにしています。

## 手順

このリモートリポジトリを取り込みます。

`git remote add wakin https://github.com/wakin-/mastodon.git`
`git fetch wakin`

hashtag-temp ブランチのコミットを cherry-pick します。

`git cherry-pick 5f37992dc5fb3a3729b0e5bdf6833a94d8edfeb8`

アセットファイルを更新します。

`RAILS_ENV=production bundle exec rails assets:precompile`

その後いつものようにプロセスの再起動で完了です。