### PR TITLE
Fix to reject status quotations other than public and unlisted

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -77,6 +77,7 @@ class Status < ApplicationRecord
   validates_with DisallowedHashtagsValidator
   validates :reblog, uniqueness: { scope: :account }, if: :reblog?
   validates :visibility, exclusion: { in: %w(direct limited) }, if: :reblog?
+  validates :quote_visibility, inclusion: { in: %w(public unlisted) }, if: :quote?
 
   accepts_nested_attributes_for :poll
 
@@ -165,6 +166,10 @@ class Status < ApplicationRecord
 
   def quote?
     !quote_id.nil? && quote
+  end
+
+  def quote_visibility
+    quote&.visibility
   end
 
   def within_realtime_window?


### PR DESCRIPTION
APIで直接quote_idを指定した際に、privateやdirectの投稿を引用しないようにする